### PR TITLE
Commit v0.0.3 test of ci workflow

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -12,7 +12,7 @@ jobs:
             sudo apt-get update
             sudo apt install -y python3-pip
             sudo pip install pipenv
-            pipenv install dist/motionrender-0.0.2-py3-none-any.whl
+            pipenv install dist/motionrender-0.0.3-py3-none-any.whl
             pipenv install pytest
       - run:
           command: | # Run test suite

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,4 +12,15 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 - Project setup, build, test, publish framework
 - Added environemnt variables for circlci publish test/publish ci workflow
 
+## [0.0.3] - 2023-05-17
+
+### Added
+
+- Continuing testing ci workflow issues.  In this commit we test correctly
+  updating the version and using a pull request.  We will pull this
+  code to a develop branch.  Whenever a commit is made/pulled to this branch,
+  it should invoke the ci workflow that does a build_test and
+  then does the test_pypi_publish.  We hopefully now have our password
+  issues worked out for twine.
+
 

--- a/setup.py
+++ b/setup.py
@@ -1,6 +1,6 @@
 from setuptools import setup, find_packages
 
-VERSION = '0.0.2'
+VERSION = '0.0.3'
 DESCRIPTION = 'A motion tracking 3D movier render'
 LONG_DESCRIPTION = 'A package that renders movies from 3D motion tracked data, for example from 3D skeleton joint tracking data'
 


### PR DESCRIPTION
Continuing testing ci workflow issues.  In this commit we test correctly updating the version and using a pull request.  We will pull this code to a develop branch.  Whenever a commit is made/pulled to this branch, it should invoke the ci workflow that does a build_test and then does the test_pypi_publish.  We hopefully now have our password issues worked out for twine.