### PR TITLE
add requirements files and dev setup instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,3 +14,17 @@ package relies on Python 3 Matplotlib plotting and movie animations
 using the and `matplotlib.animation`
 libraries.  This package uses mpeg as a back end renderer to create
 the rendered animations.
+
+
+## Development
+
+Install `ffmpeg` using your system package manager, e.g.
+`sudo apt install ffmpeg` on Ubuntu  
+`brew install ffmpeg` on MacOS (with [homebrew](https://brew.sh/))
+
+
+1. `git clone https://github.com/DerekHarter/motionrender`
+2. `cd motionrender`
+3. `pip install -r requirements-dev.txt`
+4. `pip install -e .` Install in dev mode so changes are automatically updated
+5. `pytest` to run all tests or `pytest -k testname ` to run a specific test

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -1,0 +1,2 @@
+-r requirements.txt
+pytest

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,2 @@
+pandas
+matplotlib

--- a/setup.py
+++ b/setup.py
@@ -4,6 +4,9 @@ VERSION = '1.0.0'
 DESCRIPTION = 'A motion tracking 3D movier render'
 LONG_DESCRIPTION = 'A package that renders movies from 3D motion tracked data, for example from 3D skeleton joint tracking data'
 
+with open("requirements.txt") as f:
+    requirements = f.read().splitlines()
+
 setup(
     name="motionrender",
     version=VERSION,
@@ -13,7 +16,7 @@ setup(
     author_email="Derek.Harter@tamuc.edu",
     license='GPL-3',
     packages=find_packages(),
-    install_requires=[],
+    install_requires=requirements,
     keywords='motion tracking, 3D rendering',
     classifiers= [
         "Development Status :: 3 - Alpha",


### PR DESCRIPTION
Hi @DerekHarter ,

As per one of the suggestions in my review I've added matplotlib and pandas as dependencies using a `requirements.txt` file. This should help users in the future just do `pip install motionrender` without having to also `pip install matplotlib pandas`

Feel free to keep or scrap any of these suggestions!